### PR TITLE
Update to Exmod.Exiled 9.0.0-beta1, Replace SpawnTeamType to Team bec…

### DIFF
--- a/Parser/TagParser/TagParserUtilities/NameTranslator.cs
+++ b/Parser/TagParser/TagParserUtilities/NameTranslator.cs
@@ -77,7 +77,9 @@ namespace CustomizableUIMeow.Parser.TagParser.ParserUtilities
 
         public static string GetName(SpawnableTeamType spawningTeamType)
         {
-            if (PluginTranslation.RespawnTeamDictionary.TryGetValue(spawningTeamType, out string name))
+            //I have no idea yet. but this fixed is work for some reason.
+            //TODO: Hope Fansh fix this.
+            if (PluginTranslation.RespawnTeamDictionary.TryGetValue((Team)spawningTeamType, out string name))
             {
                 return name;
             }

--- a/PluginTranslation.cs
+++ b/PluginTranslation.cs
@@ -124,12 +124,13 @@ namespace CustomizableUIMeow
             {ZoneType.Unspecified, "Unspecified" }
         };
 
+        //I don't fucking know it is work on other people. but it's worked on me.
         [Description("PluginTranslation of different respawnable role types")]
-        public Dictionary<SpawnableTeamType, string> RespawnTeamDictionary { get; private set; } = new Dictionary<SpawnableTeamType, string>
+        public Dictionary<Team, string> RespawnTeamDictionary { get; private set; } = new Dictionary<Team, string>
         {
-            {SpawnableTeamType.NineTailedFox,"<color=#0096FF>NTF</color>" },
-            {SpawnableTeamType.ChaosInsurgency,"<color=#0D7D35>Chaos Insurgency</color>" },
-            {SpawnableTeamType.None, "None" }
+            {Team.FoundationForces, "<color=#0096FF>NTF</color>" },
+            {Team.ChaosInsurgency, "<color=#0D7D35>Chaos Insurgency</color>" },
+            {Team.Dead, "None" } 
         };
 
         [Description("PluginTranslation of different warhead status")]

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EXILEDOFFICIAL" version="8.11.0" targetFramework="net481" />
+  <package id="ExMod.Exiled" version="9.0.0-beta.1" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Update to Exmod.Exiled 9.0.0-beta1, Replace SpawnTeamType to Team because Exiled removed it.
Dear @MeowServer Please update the UI Template files in Team.